### PR TITLE
Fix README env variable wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To show sample code for student
 Data Structure Display System (DSDS)
 
 1. 創建DS_exe, DS_source, exestation
-2. 建立.env 內部包含 session secret, account, password, promises queue max value
+2. 建立.env 內部包含 session secret, account, password, promise queue max value (NUMBER_OF_CONCURRENT_TASKS)
    
    #session secret
 


### PR DESCRIPTION
## Summary
- clarify environment variable name in README step 2

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fb7d83b80832eb34f99847b1ad122